### PR TITLE
Parameterize the output streams of run-command

### DIFF
--- a/commands.lisp
+++ b/commands.lisp
@@ -1,16 +1,19 @@
 (uiop:define-package :cl-scripting/commands
   (:use :cl :uiop :cl-launch/dispatch :cl-scripting/failure)
-  (:export #:run-command #:register-command #:register-commands))
+  (:export #:run-command #:register-command #:register-commands #:*failure-output* #:*success-output*))
 
 (in-package :cl-scripting/commands)
+
+(defvar *failure-output* t)
+(defvar *success-output* t)
 
 (defun run-command (fun &rest args)
   (let ((results (multiple-value-list (with-failure-context () (apply fun args)))))
     ;; Don't print anything on success for regular commands, otherwise print all values returned.
     (if (failurep results)
         (let ((failures (failure-failures results)))
-          (format t "~&Failure~P:~{~& ~A~}~&" (length failures) failures))
-        (format t "~{~&~S~&~}" (if (successp results) (success-values results) results)))
+          (format *failure-output* "~&Failure~P:~{~& ~A~}~&" (length failures) failures))
+        (format *success-output* "~{~&~S~&~}" (if (successp results) (success-values results) results)))
     (apply 'values results)))
 
 (defun register-command (command)


### PR DESCRIPTION
This change allows, e.g.:

(setf cl-scripting:\*failure-output* \*error-output*)

or even wrapping a run-command invocation in a (with-output-to-string ...)